### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 "name": CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Sumit-Kumar1/auth-rest-api/security/code-scanning/2](https://github.com/Sumit-Kumar1/auth-rest-api/security/code-scanning/2)

In general, the fix is to define explicit `permissions` for the workflow or per job, setting them to the minimal scope needed. For this workflow, neither job needs to write to the repository; they just read source code and push Docker images to Docker Hub using explicit credentials. Therefore, setting `contents: read` at the workflow level is an appropriate minimal configuration. If in the future a job needs broader permissions, a job‑specific `permissions` block can override the workflow default.

The single best fix with no behavior change is to add a top‑level `permissions:` block (applies to all jobs) between the `name` and `on` keys, setting `contents: read`. This will restrict the `GITHUB_TOKEN` to read‑only access to repository contents while leaving all existing steps functional, since none require write access to GitHub. No additional imports or methods are needed; this is a pure YAML configuration change in `.github/workflows/ci.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
