### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 "name": CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Sumit-Kumar1/auth-rest-api/security/code-scanning/1](https://github.com/Sumit-Kumar1/auth-rest-api/security/code-scanning/1)

To fix this, explicitly restrict the `GITHUB_TOKEN` permissions for the workflow to the least privileges needed. Both jobs only need to read repository contents (for `actions/checkout`), while image publishing uses Docker Hub credentials, not `GITHUB_TOKEN`. Thus, a workflow-level `permissions` block with `contents: read` is sufficient and will apply to all jobs that do not override it.

Concretely, in `.github/workflows/ci.yaml`, add a `permissions:` section near the top of the file, alongside `on:` and `jobs:`. This should be at the root level (no extra indentation) and can be placed after the `name` declaration and before `on:` or between `on:` and `jobs:` as long as YAML structure remains valid. No imports or additional methods are needed—only the YAML key/value block. This change keeps existing functionality intact while ensuring the `GITHUB_TOKEN` cannot write to the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
